### PR TITLE
contenedores, fechas banner y menu mobile

### DIFF
--- a/src/components/generalNews/index.js
+++ b/src/components/generalNews/index.js
@@ -7,7 +7,7 @@ class GeneralComponent extends Component {
     const { title, content } = this.props.data
     return (
       <GeneralNewsSection>
-        <Container>
+        <Container xlStaticSize>
           <GeneralTitle>
             <h1>{title.text}</h1>
             <div dangerouslySetInnerHTML={{ __html: content.html }} />

--- a/src/components/homeHeader/index.styled.js
+++ b/src/components/homeHeader/index.styled.js
@@ -16,6 +16,7 @@ const BannerImg = styled.div`
     url(${props => (props.bg ? props.bg : bg)});
   width: 100%;
   min-height: ${props => (props.fullHeight ? "600px" : "300px")};
+
   ${props => props.theme.ipadBreakPoint} {
     min-height: ${props => (props.fullHeight ? "440px" : "200px")};
   }
@@ -23,9 +24,7 @@ const BannerImg = styled.div`
   ${props => props.theme.smallBreakPoint} {
     min-height: ${props => (props.fullHeight ? "340px" : "200px")};
   }
-
   ${props => props.theme.xlBreakPoint} {
-    background-image: url(${props => (props.bg ? props.bg : bg)});
   }
 `
 

--- a/src/components/mainNews/subNews.js
+++ b/src/components/mainNews/subNews.js
@@ -6,36 +6,22 @@ import {
   Paragraph,
   Col,
 } from "../../theme/index.styled"
+import moment from "moment"
+import "moment/locale/es"
+moment.locale("es")
+
 class SubNewComponent extends Component {
   render() {
-    const Months = [
-      "Enero",
-      "Febrero",
-      "Marzo",
-      "Abril",
-      "Mayo",
-      "Junio",
-      "Julio",
-      "Agosto",
-      "Septiembre",
-      "Octubre",
-      "Noviembre",
-      "Diciembre",
-    ]
-    let date = new Date(this.props.notice.data.custom_publishdate)
-    let trueDate =
-      Months[date.getMonth()] +
-      " " +
-      date.getDate() +
-      " | " +
-      date.getFullYear()
     return (
       <MainNewSmall>
         <hr />
         <Col>
           <ImageWrapper>
             <a href={`/${this.props.notice.uid}`}>
-              <img alt="prueba" src={this.props.notice.data.banner.thumbnail.url} />
+              <img
+                alt="prueba"
+                src={this.props.notice.data.banner.thumbnail.url}
+              />
             </a>
           </ImageWrapper>
         </Col>
@@ -52,7 +38,10 @@ class SubNewComponent extends Component {
                 {" "}
                 Por <b> {this.props.notice.data.author[0].name.text} </b>{" "}
               </i>{" "}
-              <br /> {trueDate}
+              <br />{" "}
+              {moment(this.props.notice.data.custom_publishdate).format(
+                "MMMM DD [|] YYYY"
+              )}
             </AuthorContainer>
           </MainNewSmallText>
         </Col>

--- a/src/components/notice/authors.js
+++ b/src/components/notice/authors.js
@@ -93,7 +93,7 @@ const AuthorsNoticeComponent = ({ color, authors, align }) => {
     return special == "left" ? "Contacta al Autor" : "Créditos"
   }
   return (
-    <Container size="medium">
+    <Container size="medium" xlStaticSize>
       <Divider />
       {/**color={authors[0].color} align={authors[0].align} */}
       <NoticeSectionTitle align={align} color={color}>

--- a/src/components/notice/donate.js
+++ b/src/components/notice/donate.js
@@ -5,11 +5,11 @@ import { DonateContainer } from "./index.styled"
 const NormalDonateComponent = () => {
   return (
     <React.Fragment>
-      <DonateContainer size="medium">
-        <i class="icon-donar"/>
-          <h2>El periodismo requiere de tu apoyo</h2>
-          <p>Conviértete en miembro del Border Hub</p>
-          <button> Donar </button>
+      <DonateContainer size="medium" xlStaticSize>
+        <i class="icon-donar" />
+        <h2>El periodismo requiere de tu apoyo</h2>
+        <p>Conviértete en miembro del Border Hub</p>
+        <button> Donar </button>
       </DonateContainer>
     </React.Fragment>
   )

--- a/src/components/notice/header.js
+++ b/src/components/notice/header.js
@@ -35,7 +35,7 @@ const HeaderNoticeComponent = ({ url, notice, align }) => {
 
   return (
     <React.Fragment>
-      <Container size="medium">
+      <Container size="medium" xlStaticSize>
         <NoticeTitleWrapper align={align}>
           <h1>{title.text}</h1>
           <p>

--- a/src/components/notice/related.js
+++ b/src/components/notice/related.js
@@ -16,14 +16,15 @@ const NormalRelatedComponent = ({ color, related }) => {
   const getDate = date => moment(date).format("MMMM DD, YYYY [|] h:mm a")
   return (
     <React.Fragment>
-      <Container size="medium">
+      <Container size="medium" xlStaticSize>
         <YellowTitle>Notas Relacionadas</YellowTitle>
         {related.map((item, index) => (
           <MainNewSmall key={index}>
             <Col>
               <ImageWrapper>
                 <a href={`/${item.uid}`}>
-                  {item.data.banner.thumbnail && item.data.banner.thumbnail.url ? (
+                  {item.data.banner.thumbnail &&
+                  item.data.banner.thumbnail.url ? (
                     <img alt="prueba" src={item.data.banner.thumbnail.url} />
                   ) : (
                     ""

--- a/src/components/notice/suscribe.js
+++ b/src/components/notice/suscribe.js
@@ -6,7 +6,7 @@ import { TitleMediumContainer, Rows, FormBody } from "../../theme/index.styled"
 class NormalSubscribeComponent extends Component {
   render() {
     return (
-      <YellowContainer size="medium">
+      <YellowContainer size="medium" xlStaticSize>
         <TitleMediumContainer color={true}>
           <h3>Unete a nuestro newsletter.</h3>
           <FormBody color id="mc_embed_signup">

--- a/src/components/notice/textContent.js
+++ b/src/components/notice/textContent.js
@@ -4,16 +4,21 @@ import { Container } from "../../theme/index.styled"
 
 const TextNoticeContentComponent = ({ notice }) => {
   const getContent = () => {
-    return notice.primary ? notice.primary.content.html : notice.data.content.html
-  } 
+    return notice.primary
+      ? notice.primary.content.html
+      : notice.data.content.html
+  }
   const getColor = () => {
     return notice.primary ? "white" : "black"
-  } 
-  
+  }
+
   return (
     <React.Fragment>
-      <Container size="medium">
-        <TextWrapper color={getColor()}  dangerouslySetInnerHTML={{ __html: getContent() }}/>
+      <Container size="medium" xlStaticSize>
+        <TextWrapper
+          color={getColor()}
+          dangerouslySetInnerHTML={{ __html: getContent() }}
+        />
       </Container>
     </React.Fragment>
   )

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -51,7 +51,9 @@ class SidebarComponent extends Component {
           >
             <i />
           </Hamburguer>
-          <img alt="Border center" src={logo} />
+          <a href="/">
+            <img alt="Border center" src={logo} />
+          </a>
           <ul>
             {menu.map((item, index) => (
               <li key={index}>

--- a/src/components/sidebar/index.styled.js
+++ b/src/components/sidebar/index.styled.js
@@ -173,6 +173,7 @@ const Menu = styled.div`
   }
   ${props => props.theme.smallBreakPoint} {
     width: 100%;
+    min-width: 100%;
   }
   ${props => props.theme.largeBreakPoint} {
     min-width: 538px;

--- a/src/components/specials/index.styled.js
+++ b/src/components/specials/index.styled.js
@@ -10,8 +10,8 @@ import bg from "../../theme/images/1.jpg"
 const SpecialSection = styled(Section)`
   background: linear-gradient(
       to right,
-      ${props => props.theme.Black}99 20%,
-      ${props => props.theme.Red}99
+      rgba(31, 25, 26, 0.6) 20%,
+      rgba(153, 18, 18, 0.6)
     ),
     url(${props => (props.bg ? props.bg : bg)});
   background-position: center;

--- a/src/theme/index.styled.js
+++ b/src/theme/index.styled.js
@@ -52,7 +52,10 @@ const Container = styled.div`
   ${props => (props.size === "full" ? "max-width: 100%;" : "")}
 
   ${props => props.theme.largeBreakPoint} {
-    max-width: ${props => props.theme.ContainerExtraLarge}px;
+    ${props =>
+      props.xlStaticSize
+        ? ""
+        : "max-width:" + props.theme.ContainerExtraLarge + "px;"};
   }
 `
 const RowGap = gap => {


### PR DESCRIPTION
Contenedores de ancho máximo para pantallas grandes, fix de fechas en edge y safari, mobile fix ancho del menu, mobile home banner mantener shadow