### PR TITLE
home banner cambia por noticias y noticias especiales

### DIFF
--- a/src/components/homeHeader/index.js
+++ b/src/components/homeHeader/index.js
@@ -22,12 +22,10 @@ class HomeHeaderComponent extends Component {
     return moment(notice.data.custom_publishdate).format("MMMM DD [|] YYYY")
   }
   render() {
-    const notice =
-      this.props.bannerNotice.nodes.length > 0
-        ? this.props.bannerNotice.nodes[0]
-        : {}
+    const notice = this.props.bannerNotice[0]
+    console.log("NOTICE", notice)
     const rows =
-      this.props.bannerNotice.nodes.length === 0 ? (
+      this.props.bannerNotice.length === 0 ? (
         <Rows />
       ) : (
         <Rows>

--- a/src/components/homeHeader/index.js
+++ b/src/components/homeHeader/index.js
@@ -55,9 +55,10 @@ class HomeHeaderComponent extends Component {
           </Row>
         </Rows>
       )
+    const banner = notice.data.banner.url ? notice.data.banner.url : bodyImage
     return (
       <Banner>
-        <BannerImg fullHeight={true} bg={bodyImage} />
+        <BannerImg fullHeight={true} bg={banner} />
         <BannerContainer fullHeight={false}>{rows}</BannerContainer>
       </Banner>
     )

--- a/src/components/notice/special.js
+++ b/src/components/notice/special.js
@@ -67,7 +67,7 @@ class SpecialNoticeComponent extends Component {
         <AuthorsNoticeComponent
           color="white"
           align="center"
-          authors={this.props.notice.data.authors}
+          authors={this.props.notice.data.author}
         />
         <AlliancesNoticeContentComponent
           alliances={this.props.notice.data.alliances}

--- a/src/components/recentNews/index.js
+++ b/src/components/recentNews/index.js
@@ -1,5 +1,10 @@
 import React, { Component } from "react"
-import { CustomTitle, RecentSection, PrincipalContainer, HrCol } from "./index.styled"
+import {
+  CustomTitle,
+  RecentSection,
+  PrincipalContainer,
+  HrCol,
+} from "./index.styled"
 import SubNewComponent from "./subNews.js"
 import { Col, Container } from "../../theme/index.styled"
 
@@ -11,9 +16,10 @@ class RecentNews extends Component {
     return r
   }
   render() {
-    const mergeNotices = this.props.bannerNotices.nodes.concat(
-      this.props.principalNotices.nodes
-    )
+    // const mergeNotices = this.props.bannerNotices.nodes.concat(
+    //   this.props.principalNotices.nodes
+    // )
+    const mergeNotices = this.props.principalNotices.nodes
     return (
       <RecentSection>
         <Container size="large">

--- a/src/containers/specialnote.js
+++ b/src/containers/specialnote.js
@@ -76,23 +76,23 @@ export const pageQuery = graphql`
           url
           alt
         }
-        authors {
-          author_profile {
+        author {
+          user_picture {
             url
           }
-          author_name {
+          name {
             text
           }
           author_rol {
             text
           }
-          author_email {
+          email {
             text
           }
-          author_facebook {
+          facebook {
             text
           }
-          author_twitter {
+          twitter {
             text
           }
         }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -36,6 +36,7 @@ export const pageQuery = graphql`
     bannerNotice: allPrismicNoticias(
       limit: 1
       filter: { data: { type: { eq: "banner" } } }
+      sort: { fields: [data___custom_publishdate], order: [DESC] }
     ) {
       nodes {
         uid
@@ -65,6 +66,7 @@ export const pageQuery = graphql`
     normalNotices: allPrismicNoticias(
       limit: 3
       filter: { data: { type: { eq: "normal" } } }
+      sort: { fields: [data___custom_publishdate], order: [DESC] }
     ) {
       nodes {
         uid
@@ -94,7 +96,10 @@ export const pageQuery = graphql`
         }
       }
     }
-    recentNotices: allPrismicNoticias(limit: 8) {
+    recentNotices: allPrismicNoticias(
+      limit: 8
+      sort: { fields: [data___custom_publishdate], order: [DESC] }
+    ) {
       nodes {
         uid
         data {
@@ -123,7 +128,9 @@ export const pageQuery = graphql`
         }
       }
     }
-    allPrismicNoticias {
+    allPrismicNoticias(
+      sort: { fields: [data___custom_publishdate], order: [DESC] }
+    ) {
       nodes {
         data {
           custom_publishdate

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,11 +8,12 @@ const temp = data => {
   const common = data.data.prismicDatosComunes.data
   const description = common.metadescription.text
   const keywords = common.metakeywords.text
+  console.log("BANNER ???", common.banner.document)
   return (
     <Layout>
       <SEO title="Home" description={description} keywords={keywords} />
       <HomeContainer
-        bannerNotice={data.data.bannerNotice}
+        bannerNotice={common.banner.document}
         normalNotices={data.data.normalNotices}
         recentNotices={data.data.recentNotices}
         noticeP={data.data.allPrismicNoticias}
@@ -30,6 +31,28 @@ export const pageQuery = graphql`
         }
         metakeywords {
           text
+        }
+        banner {
+          document {
+            uid
+            data {
+              custom_publishdate
+              title {
+                text
+              }
+              banner {
+                url
+              }
+              excerpt {
+                text
+              }
+              author {
+                name {
+                  text
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -157,7 +180,7 @@ export const pageQuery = graphql`
     }
     allPrismicNoticiasEspeciales(
       limit: 1
-      sort: { fields: [last_publication_date], order: [DESC] }
+      sort: { fields: [data___custom_publishdate], order: [DESC] }
     ) {
       nodes {
         uid
@@ -175,23 +198,23 @@ export const pageQuery = graphql`
           excerpt {
             text
           }
-          authors {
-            author_profile {
+          author {
+            user_picture {
               url
             }
-            author_name {
+            name {
               text
             }
             author_rol {
               text
             }
-            author_email {
+            email {
               text
             }
-            author_facebook {
+            facebook {
               text
             }
-            author_twitter {
+            twitter {
               text
             }
           }


### PR DESCRIPTION
Ahora la noticia del banner se llena en datos comunes. 
Ahí se agregó un tipo de dato "Content relationship" el cual permite hacer un link a noticas y noticias especiales.
Para este cambio se normalizaron nombres de propiedades de las noticias para que no hayan conflictos