### PR TITLE
fix notice size on big screens

### DIFF
--- a/src/components/homeHeader/index.js
+++ b/src/components/homeHeader/index.js
@@ -28,7 +28,7 @@ class HomeHeaderComponent extends Component {
         <Rows />
       ) : (
         <Rows>
-          <Row shrink>
+          <Row shrink shrinkXl>
             <AuthorContainer main={true} show={true} color={true}>
               <i>
                 Por <b> {this.getAuthor(notice)}</b>
@@ -36,7 +36,7 @@ class HomeHeaderComponent extends Component {
               <br /> {this.getDate(notice)}
             </AuthorContainer>
           </Row>
-          <Row shrink>
+          <Row shrink shrinkXl>
             <TitleContainer fullHeight={true}>
               <h1>
                 <a href={`/${notice.uid}`}>{notice.data.title.text}</a>

--- a/src/theme/index.styled.js
+++ b/src/theme/index.styled.js
@@ -116,6 +116,7 @@ const Row = styled.div`
   ${props => props.theme.largeBreakPoint} {
     flex: ${props => (props.widthXl ? "0 1 " + props.widthXl : "1 0 auto")};
     max-width: ${props => (props.widthXl ? props.widthXl : "100%")};
+    ${props => (props.shrinkXl ? "flex: 0 1 auto;" : "")}
   }
   ${props => props.theme.mediumBreakPoint} {
     flex: ${props => (props.widthXs ? "0 1 " + props.widthXs : "1 0 auto")};


### PR DESCRIPTION
What does this PR do?

- Se agregó un prop para pantallas grandes en el styled component "Row"

Where should the reviewer start from?

- src/theme/index.styled.js

- src/components/homeHeader/index.js

Any background context you want to provide?
El banner del home se descuadraba en pantallas grandes. El problema era que el row debía tener la propiedad flex: 0 1 auto, pero el media query lo sobreescribía. 