### PR TITLE
Changed url by type of notice

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -40,10 +40,11 @@ exports.createPages = async ({ graphql, actions }) => {
   `)
 
   const specialNote = path.resolve("src/containers/specialnote.js")
+  const { SPECIAL_NEWS_URL, NEWS_URL } = require('./src/utils/constants');
 
   pages.data.allPrismicNoticiasEspeciales.edges.forEach(edge => {
     createPage({
-      path: `/${edge.node.uid}`,
+      path: `/${SPECIAL_NEWS_URL}/${edge.node.uid}`,
       component: specialNote,
       context: {
         uid: edge.node.uid,
@@ -56,7 +57,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
   pages.data.allPrismicNoticias.edges.forEach(edge => {
     createPage({
-      path: `/${edge.node.uid}`,
+      path: `/${NEWS_URL}/${edge.node.uid}`,
       component: normalNote,
       context: {
         uid: edge.node.uid,

--- a/src/components/homeHeader/index.js
+++ b/src/components/homeHeader/index.js
@@ -8,6 +8,7 @@ import {
   TitleContainer,
   Paragraph,
 } from "../../theme/index.styled"
+import { SPECIAL_NEWS_URL, NEWS_URL } from '../../utils/constants'
 
 import moment from "moment"
 import "moment/locale/es"
@@ -23,6 +24,7 @@ class HomeHeaderComponent extends Component {
   }
   render() {
     const notice = this.props.bannerNotice[0]
+    const urlSectionType =  (notice.type == 'noticias_especiales')? SPECIAL_NEWS_URL:NEWS_URL
     const rows =
       this.props.bannerNotice.length === 0 ? (
         <Rows />
@@ -39,7 +41,7 @@ class HomeHeaderComponent extends Component {
           <Row shrink shrinkXl>
             <TitleContainer fullHeight={true}>
               <h1>
-                <a href={`/${notice.uid}`}>{notice.data.title.text}</a>
+                <a href={`/${urlSectionType}/${notice.uid}`}>{notice.data.title.text}</a>
               </h1>
               <AuthorContainer show={false} color={true}>
                 <i>

--- a/src/components/mainNews/index.js
+++ b/src/components/mainNews/index.js
@@ -10,6 +10,8 @@ import {
   ImageWrapper,
   YellowTitle,
 } from "../../theme/index.styled"
+import { SPECIAL_NEWS_URL, NEWS_URL } from '../../utils/constants'
+
 import SubNewComponent from "./subNews.js"
 import moment from "moment"
 import "moment/locale/es"
@@ -19,17 +21,18 @@ class MainNewsComponent extends Component {
   getDate = date => moment(date).format("MMMM DD")
   getComponent = (data, i) => {
     const noticeLen = Object.keys(this.props.notice).length
+    const urlSectionType =  (data.type == 'noticias_especiales')? SPECIAL_NEWS_URL:NEWS_URL
     if (noticeLen === i + 1) {
       return (
         <React.Fragment>
           <ImageWrapper>
-            <a href={`/${data.uid}`}>
+            <a href={`/${urlSectionType}/${data.uid}`}>
               <img alt={data.data.title.text} src={data.data.banner.url} />
             </a>
           </ImageWrapper>
           <TextContainer>
             <h2>
-              <a href={`/${data.uid}`}>{data.data.title.text}</a>
+              <a href={`/${urlSectionType}/${data.uid}`}>{data.data.title.text}</a>
             </h2>
             <SubTitleParagraph>{data.data.excerpt.text}</SubTitleParagraph>
             <AuthorContainer show>

--- a/src/components/mainNews/subNews.js
+++ b/src/components/mainNews/subNews.js
@@ -1,18 +1,21 @@
 import React, { Component } from "react"
 import { MainNewSmall, MainNewSmallText, MobileParagraph } from "./index.styled"
 import { AuthorContainer, ImageWrapper, Col } from "../../theme/index.styled"
+import { SPECIAL_NEWS_URL, NEWS_URL } from '../../utils/constants'
+
 import moment from "moment"
 import "moment/locale/es"
 moment.locale("es")
 
 class SubNewComponent extends Component {
   render() {
+    const urlSectionType =  (this.props.darkMode)? SPECIAL_NEWS_URL:NEWS_URL
     return (
       <MainNewSmall>
         <hr />
         <Col>
           <ImageWrapper>
-            <a href={`/${this.props.notice.uid}`}>
+            <a href={`/${urlSectionType}/${this.props.notice.uid}`}>
               <img
                 alt="prueba"
                 src={this.props.notice.data.banner.thumbnail.url}
@@ -23,7 +26,7 @@ class SubNewComponent extends Component {
         <Col>
           <MainNewSmallText darkMode={this.props.darkMode}>
             <h3>
-              <a href={`/${this.props.notice.uid}`}>
+              <a href={`/${urlSectionType}/${this.props.notice.uid}`}>
                 {this.props.notice.data.title.text}
               </a>
             </h3>

--- a/src/components/notice/multinotes.js
+++ b/src/components/notice/multinotes.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { VerticalNotice } from "./index.styled"
 import { Container, Rows, Row } from "../../theme/index.styled"
+import { SPECIAL_NEWS_URL, NEWS_URL } from '../../utils/constants'
 
 import moment from "moment"
 import "moment/locale/es"
@@ -11,6 +12,7 @@ const MultinotesContentComponent = ({ notice }) => {
   const partial = items.map((item, index) => {
     const notice = item.note.document[0]
     const date = notice.data.custom_publishdate
+    const urlSectionType =  (notice.type == 'noticias_especiales')? SPECIAL_NEWS_URL:NEWS_URL
     console.log("notice", notice)
     return (
       <Row key={index} width="45%" widthXs="45%" widthXl="30%">
@@ -23,10 +25,10 @@ const MultinotesContentComponent = ({ notice }) => {
           </a>
           <div className="text-wrapper">
             <h3>
-              <a href={`/${notice.uid}`}>{item.title_note.text}</a>
+              <a href={`/${urlSectionType}/${notice.uid}`}>{item.title_note.text}</a>
             </h3>
             <h4>
-              <a href={`/${notice.uid}`}>{notice.data.title.text}</a>
+              <a href={`/${urlSectionType}/${notice.uid}`}>{notice.data.title.text}</a>
             </h4>
             <div className="excerpt">
               {notice.data.excerpt.text.slice(0, 80)}

--- a/src/components/notice/related.js
+++ b/src/components/notice/related.js
@@ -7,6 +7,7 @@ import {
   Col,
   ImageWrapper,
 } from "../../theme/index.styled"
+import { SPECIAL_NEWS_URL, NEWS_URL } from '../../utils/constants'
 
 import moment from "moment"
 import "moment/locale/es"
@@ -18,11 +19,13 @@ const NormalRelatedComponent = ({ color, related }) => {
     <React.Fragment>
       <Container size="medium" xlStaticSize>
         <YellowTitle>Notas Relacionadas</YellowTitle>
-        {related.map((item, index) => (
+        {related.map((item, index) => {
+          const urlSectionType =  (item.type == 'noticias_especiales')? SPECIAL_NEWS_URL:NEWS_URL
+          return (
           <MainNewSmall key={index}>
             <Col>
               <ImageWrapper>
-                <a href={`/${item.uid}`}>
+                <a href={`/${urlSectionType}/${item.uid}`}>
                   {item.data.banner.thumbnail &&
                   item.data.banner.thumbnail.url ? (
                     <img alt="prueba" src={item.data.banner.thumbnail.url} />
@@ -35,7 +38,7 @@ const NormalRelatedComponent = ({ color, related }) => {
             <Col>
               <MainNewSmallText color={color}>
                 <h3>
-                  <a href={`/${item.uid}`}>{item.data.title[0].text}</a>
+                  <a href={`/${urlSectionType}/${item.uid}`}>{item.data.title[0].text}</a>
                 </h3>
                 <AuthorContainer color={color} show={true}>
                   {getDate(
@@ -47,7 +50,8 @@ const NormalRelatedComponent = ({ color, related }) => {
               </MainNewSmallText>
             </Col>
           </MainNewSmall>
-        ))}
+        )}
+      )}
       </Container>
     </React.Fragment>
   )

--- a/src/components/recentNews/subNews.js
+++ b/src/components/recentNews/subNews.js
@@ -7,6 +7,7 @@ import {
   TextCol,
   YellowText,
 } from "./index.styled"
+import { SPECIAL_NEWS_URL, NEWS_URL } from '../../utils/constants'
 import { ImageWrapper, Paragraph } from "../../theme/index.styled"
 import tempImg from "../../theme/images/3.jpg"
 
@@ -26,14 +27,15 @@ class SubNewComponent extends Component {
       custom_publishdate,
     } = this.props.notice.data
     const limit = 50
-  console.log('NOTICE',this.props.notice)
+    const urlSectionType =  (this.props.notice.type == 'noticias_especiales')? SPECIAL_NEWS_URL:NEWS_URL
+    console.log('NOTICE',this.props.notice)
 
     return (
       <NewsContainer>
         <TextCol>
           <NewsText>
             <h3>
-              <a href={`/${this.props.notice.uid}`}>{title.text}</a>
+              <a href={`/${urlSectionType}/${this.props.notice.uid}`}>{title.text}</a>
             </h3>
             <Paragraph>
               {excerpt.text && excerpt.text.length > limit
@@ -49,7 +51,7 @@ class SubNewComponent extends Component {
         </TextCol>
         <ImgCol>
           <ImageWrapper>
-            <a href={`/${this.props.notice.uid}`}>
+            <a href={`/${urlSectionType}/${this.props.notice.uid}`}>
               <img src={banner.thumbnail.url} />
             </a>
           </ImageWrapper>

--- a/src/components/specials/index.js
+++ b/src/components/specials/index.js
@@ -6,10 +6,12 @@ import {
   CustomSecondTitle,
   BigArrow,
 } from "./index.styled"
+import { SPECIAL_NEWS_URL, NEWS_URL } from '../../utils/constants'
 import { Rows, Row, Paragraph } from "../../theme/index.styled"
 
 class SpecialNews extends Component {
   render() {
+    const urlSectionType =  (this.props.notice.nodes[0].type)? SPECIAL_NEWS_URL:NEWS_URL
     return (
       <SpecialSection bg={this.props.notice.nodes[0].data.banner.url}>
         <CustomContainer size="large">
@@ -20,7 +22,7 @@ class SpecialNews extends Component {
             <Row shrink>
               <CustomSecondTitle fullHeight={false}>
                 <h1>
-                  <a href={`/${this.props.notice.nodes[0].uid}`}>
+                  <a href={`/${urlSectionType}/${this.props.notice.nodes[0].uid}`}>
                     {this.props.notice.nodes[0].data.title.text}
                   </a>
                 </h1>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,20 +7,20 @@ import HomeContainer from "../containers/home.js"
 const temp = data => {
   const common = data.data.prismicDatosComunes.data
 
-  const specialNotice = { 
-    nodes: common.special_section[0].nodes.document 
+  const specialNotice = {
+    nodes: common.special_section[0].nodes.document
   }
 
   const maxNumberOfPrincipalNews = 3
   const principalNotices = {
-    nodes: common.principal_notices.reduce((notices,notice) => {
-      if(notices.length < maxNumberOfPrincipalNews) {
+    nodes: common.principal_notices.reduce((notices, notice) => {
+      if (notices.length < maxNumberOfPrincipalNews) {
         notices.push(notice.nodes.document[0]);
       }
       return notices;
-    },[])
+    }, [])
   }
-  
+
   const description = common.metadescription.text
   const keywords = common.metakeywords.text
   console.log("BANNER ???", common.banner.document)
@@ -31,7 +31,7 @@ const temp = data => {
         bannerNotice={common.banner.document}
         normalNotices={data.data.normalNotices}
         recentNotices={data.data.recentNotices}
-        noticeS={specialNotice} 
+        noticeS={specialNotice}
         noticeP={principalNotices}
       />
     </Layout>
@@ -50,6 +50,7 @@ export const pageQuery = graphql`
         banner {
           document {
             uid
+            type
             data {
               custom_publishdate
               title {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,4 @@
+module.exports = { 
+  SPECIAL_NEWS_URL: 'noticias-especiales',
+  NEWS_URL: 'noticias',
+};


### PR DESCRIPTION
#### What does this PR do?
* Changed the notice url adding `/noticias` or `/noticias-especiales` before the `/{notice.uid}`.
* Added a constant file to handle the change of those urls in a near future.
#### Where should the reviewer start from?
* `gatsby-node.js`
* `src/utils/constants.js`
* `src/pages/index.js`
* `src/components/`
  * `homeHeader/index.js`
  * `recentNews/subNews.js`
  * `specials/index.js`
  * `mainNews/`
    * `index.js`
    * `subnews.js`
  * `notice/`
    * `multinotes.js`
    * `related.js`
  
#### Any background context you want to provide?
None.

#### Questions?