### PR TITLE
 Add type field to graph query

### DIFF
--- a/src/containers/specialnote.js
+++ b/src/containers/specialnote.js
@@ -62,6 +62,7 @@ export const pageQuery = graphql`
       uid
       prismicId
       last_publication_date
+      type
       data {
         title {
           text
@@ -216,6 +217,7 @@ export const pageQuery = graphql`
               note {
                 document {
                   uid
+                  type
                   data {
                     title {
                       text

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,4 @@
-module.exports = { 
+module.exports = {
   SPECIAL_NEWS_URL: 'noticias-especiales',
   NEWS_URL: 'noticias',
 };


### PR DESCRIPTION
adds `type` field on special notice query so the link map works.