### PR TITLE
trailing slashes for sitemap and google indexing

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -44,7 +44,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
   pages.data.allPrismicNoticiasEspeciales.edges.forEach(edge => {
     createPage({
-      path: `/${SPECIAL_NEWS_URL}/${edge.node.uid}`,
+      path: `/${SPECIAL_NEWS_URL}/${edge.node.uid}/`,
       component: specialNote,
       context: {
         uid: edge.node.uid,
@@ -57,7 +57,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
   pages.data.allPrismicNoticias.edges.forEach(edge => {
     createPage({
-      path: `/${NEWS_URL}/${edge.node.uid}`,
+      path: `/${NEWS_URL}/${edge.node.uid}/`,
       component: normalNote,
       context: {
         uid: edge.node.uid,
@@ -70,7 +70,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
   pages.data.allPrismicComun.edges.forEach(edge => {
     createPage({
-      path: `/${edge.node.uid}`,
+      path: `/${edge.node.uid}/`,
       component: general,
       context: {
         uid: edge.node.uid,

--- a/src/components/homeHeader/index.js
+++ b/src/components/homeHeader/index.js
@@ -41,7 +41,7 @@ class HomeHeaderComponent extends Component {
             <Row shrink shrinkXl>
               <TitleContainer fullHeight={true}>
                 <h1>
-                  <a href={`/${urlSectionType}/${notice.uid}`}>{notice.data.title.text}</a>
+                  <a href={`/${urlSectionType}/${notice.uid}/`}>{notice.data.title.text}</a>
                 </h1>
                 <AuthorContainer show={false} color={true}>
                   <i>

--- a/src/components/mainNews/index.js
+++ b/src/components/mainNews/index.js
@@ -26,13 +26,13 @@ class MainNewsComponent extends Component {
       return (
         <React.Fragment>
           <ImageWrapper>
-            <a href={`/${urlSectionType}/${data.uid}`}>
+            <a href={`/${urlSectionType}/${data.uid}/`}>
               <img alt={data.data.title.text} src={data.data.banner.url} />
             </a>
           </ImageWrapper>
           <TextContainer>
             <h2>
-              <a href={`/${urlSectionType}/${data.uid}`}>{data.data.title.text}</a>
+              <a href={`/${urlSectionType}/${data.uid}/`}>{data.data.title.text}</a>
             </h2>
             <SubTitleParagraph>{data.data.excerpt.text}</SubTitleParagraph>
             <AuthorContainer show>
@@ -57,7 +57,7 @@ class MainNewsComponent extends Component {
     return (
       <NewsContainer>
         <YellowTitle>
-          <a href="/noticias">Ver todas</a> Notas Principales
+          <a href="/noticias/">Ver todas</a> Notas Principales
         </YellowTitle>
         <MainNewBig size="Common">{htmlContent}</MainNewBig>
       </NewsContainer>

--- a/src/components/mainNews/subNews.js
+++ b/src/components/mainNews/subNews.js
@@ -9,13 +9,13 @@ moment.locale("es")
 
 class SubNewComponent extends Component {
   render() {
-    const urlSectionType =  (this.props.darkMode)? SPECIAL_NEWS_URL:NEWS_URL
+    const urlSectionType = (this.props.darkMode) ? SPECIAL_NEWS_URL : NEWS_URL
     return (
       <MainNewSmall>
         <hr />
         <Col>
           <ImageWrapper>
-            <a href={`/${urlSectionType}/${this.props.notice.uid}`}>
+            <a href={`/${urlSectionType}/${this.props.notice.uid}/`}>
               <img
                 alt="prueba"
                 src={this.props.notice.data.banner.thumbnail.url}
@@ -26,7 +26,7 @@ class SubNewComponent extends Component {
         <Col>
           <MainNewSmallText darkMode={this.props.darkMode}>
             <h3>
-              <a href={`/${urlSectionType}/${this.props.notice.uid}`}>
+              <a href={`/${urlSectionType}/${this.props.notice.uid}/`}>
                 {this.props.notice.data.title.text}
               </a>
             </h3>

--- a/src/components/notice/alliances.js
+++ b/src/components/notice/alliances.js
@@ -9,7 +9,7 @@ const AlliancesNoticeContentComponent = ({ alliances }) => {
       <Rows wrap align="center" vAlign="center" gap="10px">
         {alliances.map((alliance, index) =>
           alliance.alliance_image && alliance.alliance_image.url ? (
-            <a href={alliance.alliance_image.url} key={index}>
+            <a href={`${alliance.alliance_image.url}/`} key={index}>
               <img alt="" src={alliance.alliance_image.url} />
             </a>
           ) : (

--- a/src/components/notice/multinotes.js
+++ b/src/components/notice/multinotes.js
@@ -19,7 +19,7 @@ const MultinotesContentComponent = ({ notice }) => {
     return (
       <Row key={index} width="45%" widthXs="45%" widthXl="30%">
         <VerticalNotice>
-          <a className="image" href={`/${urlSectionType}/${notice.uid}`}>
+          <a className="image" href={`/${urlSectionType}/${notice.uid}/`}>
             <img
               alt={`${notice.data.title.text}`}
               src={notice.data.banner.thumbnail.url}
@@ -27,10 +27,10 @@ const MultinotesContentComponent = ({ notice }) => {
           </a>
           <div className="text-wrapper">
             <h3>
-              <a href={`/${urlSectionType}/${notice.uid}`}>{item.title_note.text}</a>
+              <a href={`/${urlSectionType}/${notice.uid}/`}>{item.title_note.text}</a>
             </h3>
             <h4>
-              <a href={`/${urlSectionType}/${notice.uid}`}>{notice.data.title.text}</a>
+              <a href={`/${urlSectionType}/${notice.uid}/`}>{notice.data.title.text}</a>
             </h4>
             <div className="excerpt">
               {notice.data.excerpt.text.slice(0, 80)}

--- a/src/components/notice/related.js
+++ b/src/components/notice/related.js
@@ -20,38 +20,39 @@ const NormalRelatedComponent = ({ color, related }) => {
       <Container size="medium" xlStaticSize>
         <YellowTitle>Notas Relacionadas</YellowTitle>
         {related.map((item, index) => {
-          const urlSectionType =  (item.type == 'noticias_especiales')? SPECIAL_NEWS_URL:NEWS_URL
+          const urlSectionType = (item.type == 'noticias_especiales') ? SPECIAL_NEWS_URL : NEWS_URL
           return (
-          <MainNewSmall key={index}>
-            <Col>
-              <ImageWrapper>
-                <a href={`/${urlSectionType}/${item.uid}`}>
-                  {item.data.banner.thumbnail &&
-                  item.data.banner.thumbnail.url ? (
-                    <img alt="prueba" src={item.data.banner.thumbnail.url} />
-                  ) : (
-                    ""
-                  )}
-                </a>
-              </ImageWrapper>
-            </Col>
-            <Col>
-              <MainNewSmallText color={color}>
-                <h3>
-                  <a href={`/${urlSectionType}/${item.uid}`}>{item.data.title[0].text}</a>
-                </h3>
-                <AuthorContainer color={color} show={true}>
-                  {getDate(
-                    item.type === "noticias"
-                      ? item.data.custom_publishdate
-                      : item.last_publication_date
-                  )}
-                </AuthorContainer>
-              </MainNewSmallText>
-            </Col>
-          </MainNewSmall>
+            <MainNewSmall key={index}>
+              <Col>
+                <ImageWrapper>
+                  <a href={`/${urlSectionType}/${item.uid}/`}>
+                    {item.data.banner.thumbnail &&
+                      item.data.banner.thumbnail.url ? (
+                        <img alt="prueba" src={item.data.banner.thumbnail.url} />
+                      ) : (
+                        ""
+                      )}
+                  </a>
+                </ImageWrapper>
+              </Col>
+              <Col>
+                <MainNewSmallText color={color}>
+                  <h3>
+                    <a href={`/${urlSectionType}/${item.uid}/`}>{item.data.title[0].text}</a>
+                  </h3>
+                  <AuthorContainer color={color} show={true}>
+                    {getDate(
+                      item.type === "noticias"
+                        ? item.data.custom_publishdate
+                        : item.last_publication_date
+                    )}
+                  </AuthorContainer>
+                </MainNewSmallText>
+              </Col>
+            </MainNewSmall>
+          )
+        }
         )}
-      )}
       </Container>
     </React.Fragment>
   )

--- a/src/components/recentNews/index.js
+++ b/src/components/recentNews/index.js
@@ -29,7 +29,7 @@ class RecentNews extends Component {
         <Container size="large">
           <CustomTitle>
             <h3>
-              <a href="/noticias">Ver todas</a> Notas Recientes
+              <a href="/noticias/">Ver todas</a> Notas Recientes
             </h3>
           </CustomTitle>
           <PrincipalContainer>
@@ -39,8 +39,8 @@ class RecentNews extends Component {
                   <SubNewComponent notice={notice} />
                 </HrCol>
               ) : (
-                ""
-              )
+                  ""
+                )
             )}
           </PrincipalContainer>
         </Container>

--- a/src/components/recentNews/subNews.js
+++ b/src/components/recentNews/subNews.js
@@ -35,7 +35,7 @@ class SubNewComponent extends Component {
         <TextCol>
           <NewsText>
             <h3>
-              <a href={`/${urlSectionType}/${this.props.notice.uid}`}>{title.text}</a>
+              <a href={`/${urlSectionType}/${this.props.notice.uid}/`}>{title.text}</a>
             </h3>
             <Paragraph>
               {excerpt.text && excerpt.text.length > limit
@@ -51,7 +51,7 @@ class SubNewComponent extends Component {
         </TextCol>
         <ImgCol>
           <ImageWrapper>
-            <a href={`/${urlSectionType}/${this.props.notice.uid}`}>
+            <a href={`/${urlSectionType}/${this.props.notice.uid}/`}>
               <img src={banner.thumbnail.url} alt={banner.thumbnail.url || banner.alt || ''} />
             </a>
           </ImageWrapper>

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -59,7 +59,7 @@ class SidebarComponent extends Component {
           <ul>
             {menu.map((item, index) => (
               <li key={index}>
-                <a href={item.item_link.url}>{item.item_name.text}</a>
+                <a href={`${item.item_link.url}/`}>{item.item_name.text}</a>
               </li>
             ))}
           </ul>

--- a/src/components/specials/index.js
+++ b/src/components/specials/index.js
@@ -43,7 +43,7 @@ class SpecialNews extends Component {
       <SpecialSection bg={this.props.notices.nodes[currentSlide].data.banner.url}>
         <CustomContainer size="large">
           <CustomTitle>
-            <a href="/noticias-especiales">Ver todas</a> Especiales
+            <a href="/noticias-especiales/">Ver todas</a> Especiales
           </CustomTitle>
           <Slider
             adaptiveHeight
@@ -60,7 +60,7 @@ class SpecialNews extends Component {
               return (
                 <CustomSecondTitle fullHeight={false} key={item.uid}>
                   <h1>
-                    <a href={`/${urlSectionType}/${item.uid}`}>
+                    <a href={`/${urlSectionType}/${item.uid}/`}>
                       {item.data.title.text}
                     </a>
                   </h1>


### PR DESCRIPTION
Add a trailing slash to correct build of site map and google indexing, this was because if we configure the site to not use the trailing slash, the current google analytics and indexing data would be be lost