### PR TITLE
Hide Special News from landing

### DIFF
--- a/src/components/recentIncidencias/index.js
+++ b/src/components/recentIncidencias/index.js
@@ -28,7 +28,7 @@ class RecentIncidencias extends Component {
       <RecentSection>
         <Container size="large">
           <CustomTitle>
-              <a href={`/incidencia/`}>Ver todas las Incidencias</a> Incidencias
+              <a href={`/incidencia/`}>Ver todas las Incidencias</a> Incidencia
           </CustomTitle>
           <PrincipalContainer>
             {this.props.notices.nodes.map(notice =>

--- a/src/components/recentIncidencias/index.js
+++ b/src/components/recentIncidencias/index.js
@@ -28,7 +28,7 @@ class RecentIncidencias extends Component {
       <RecentSection>
         <Container size="large">
           <CustomTitle>
-              <a href={`/incidencia/`}>Ver todas las Incidencias</a> Incidencia
+              <a href={`/incidencia/`}>Ver todo</a> Incidencia
           </CustomTitle>
           <PrincipalContainer>
             {this.props.notices.nodes.map(notice =>

--- a/src/components/recentIncidencias/index.js
+++ b/src/components/recentIncidencias/index.js
@@ -1,0 +1,50 @@
+import React, { Component } from "react"
+import {
+  CustomTitle,
+  RecentSection,
+  PrincipalContainer,
+  HrCol,
+} from "./index.styled"
+import SubNewComponent from "./subNews.js"
+import { Container } from "../../theme/index.styled"
+
+class RecentIncidencias extends Component {
+  isAllowed = (notice, mergeNotices) => {
+    const r = mergeNotices.reduce((result, item) => {
+      return result && item.uid === notice.uid ? false : result
+    }, true)
+    return r
+  }
+  getColor = mergeNotices => {
+    let count = 0
+    this.props.notices.nodes.map(notice =>
+      this.isAllowed(notice, mergeNotices) ? (count += 1) : ""
+    )
+    return count >= 2 ? "white" : ""
+  }
+  render() {
+    const mergeNotices = this.props.principalNotices.nodes
+    return (
+      <RecentSection>
+        <Container size="large">
+          <CustomTitle>
+              <a href={`/incidencia/`}>Ver todas las Incidencias</a> Incidencias
+          </CustomTitle>
+          <PrincipalContainer>
+            {this.props.notices.nodes.map(notice =>
+              this.isAllowed(notice, mergeNotices) ? (
+                <HrCol color={this.getColor(mergeNotices)} key={notice.uid}>
+                  <SubNewComponent notice={notice} />
+                </HrCol>
+              ) : (
+                  ""
+                )
+            )}
+          </PrincipalContainer>
+        </Container>
+      </RecentSection>
+    )
+  }
+}
+
+export default RecentIncidencias

--- a/src/components/recentIncidencias/index.styled.js
+++ b/src/components/recentIncidencias/index.styled.js
@@ -1,0 +1,154 @@
+import styled from "styled-components"
+import {
+  TitleMediumContainer,
+  Section,
+  Container,
+  Col,
+  YellowTitle,
+} from "../../theme/index.styled"
+
+const RecentSection = styled(Section)`
+  padding: 35px 24px;
+  background-color: white;
+`
+
+const CustomTitle = styled(YellowTitle)`
+  width: auto;
+  display: inline-block;
+  a {
+    margin-left: 40px;
+  }
+  ${props => props.theme.smallBreakPoint} {
+    background-color: ${props => props.theme.Yellow};
+    font-size: 30px;
+    line-height: 34.5px;
+    width: 100%;
+    padding: 15px 31px;
+    color: black;
+    a {
+      float: right;
+      font-size: 15px;
+      font-style: italic;
+      color: ${props => props.theme.Black};
+      text-decoration: underline;
+    }
+  }
+`
+const PrincipalContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  ${props => props.theme.ipadBreakPoint} {
+    margin: 0 auto;
+  }
+  ${props => props.theme.largeBreakPoint} {
+    max-width: ${props => props.theme.ContainerExtraLarge + 30}px;
+  }
+`
+
+const NewsContainer = styled(Container)`
+  display: flex;
+  flex-wrap: wrap;
+  padding-top: 1em;
+  flex-direction: column;
+  img {
+    margin: 0;
+  }
+  ${props => props.theme.xlBreakPoint} {
+    img {
+      padding: 0 0 !important;
+    }
+  }
+`
+// 205px
+const NewsText = styled(Container)`
+  max-width: 90%; 
+  margin: 0;
+  h3 {
+    color: ${props => props.theme.Black};
+    font-size: 19px;
+    font-weight: bold;
+    line-height: 1.16;
+    text-align: left;
+    margin-bottom: 15px;
+  }
+  h3 a {
+    color: ${props => props.theme.Black};
+    text-decoration: none;
+  }
+  p {
+    color: ${props => props.theme.Black};
+    text-align: left;
+    font-size: 16px;
+    line-height: 1.44;
+    margin-bottom: 15px;
+  }
+
+  ${props => props.theme.xlBreakPoint} {
+    p {
+      display: none;
+    }
+  }
+`
+
+const DateText = styled.p`
+  font-size: 15.5px;
+  color: ${props => props.theme.Black};
+  line-height: 25px;
+  line-height: 1.29;
+  text-align: left;
+  margin: 0;
+  ${props => props.theme.xlBreakPoint} {
+    color: ${props => props.theme.Black};
+  }
+`
+const TextCol = styled(Col)`
+  margin-top:20px;
+  flex: 0 0 100%;
+  max-width: 80%;
+`
+const ImgCol = styled(Col)`
+  flex: 1;
+  max-width: 100%;
+  img {
+    display: block;
+    margin: 0 auto;
+  }
+  ${props => props.theme.smallBreakPoint} {
+    flex: 1;
+    max-width: 100%;
+    
+    img {
+      height:280px;
+      display: block;
+      margin: 0 auto;
+    }
+  }
+`
+
+const YellowText = styled.span`
+  ${props => props.theme.xlBreakPoint} {
+    color: ${props => props.theme.Yellow};
+  }
+`
+const HrCol = styled(Col)`
+  padding-bottom: 20px;
+  max-width:30%;
+  border-bottom: 1px solid ${props => props.color};
+  ${props => props.theme.smallBreakPoint} {
+    max-width: 100%;
+  }
+`
+
+export {
+  CustomTitle,
+  NewsContainer,
+  NewsText,
+  PrincipalContainer,
+  DateText,
+  RecentSection,
+  ImgCol,
+  TextCol,
+  YellowText,
+  HrCol,
+}

--- a/src/components/recentIncidencias/index.styled.js
+++ b/src/components/recentIncidencias/index.styled.js
@@ -114,12 +114,22 @@ const ImgCol = styled(Col)`
     display: block;
     margin: 0 auto;
   }
-  ${props => props.theme.smallBreakPoint} {
+  ${props => props.theme.mediumBreakpoint} {
     flex: 1;
     max-width: 100%;
     
     img {
       height:280px;
+      display: block;
+      margin: 0 auto;
+    }
+  }
+  ${props => props.theme.smallBreakPoint} {
+    flex: 1;
+    max-width: 100%;
+    
+    img {
+      height:180px;
       display: block;
       margin: 0 auto;
     }

--- a/src/components/recentIncidencias/subNews.js
+++ b/src/components/recentIncidencias/subNews.js
@@ -1,0 +1,58 @@
+import React, { Component } from "react"
+import {
+  NewsContainer,
+  NewsText,
+  DateText,
+  ImgCol,
+  TextCol,
+  YellowText,
+} from "./index.styled"
+import { SPECIAL_NEWS_URL, NEWS_URL } from '../../utils/constants'
+import { ImageWrapper, Paragraph } from "../../theme/index.styled"
+import tempImg from "../../theme/images/3.jpg"
+
+import moment from "moment"
+import "moment/locale/es"
+moment.locale("es")
+
+class SubNewComponent extends Component {
+  getDate = date => moment(date).format("MMMM DD")
+  getYear = date => moment(date).format("YYYY")
+  getTime = date => moment(date).format("h:mm a")
+  render() {
+    const {
+      title,
+      banner,
+      custom_publishdate,
+    } = this.props.notice.data
+    const limit = 50
+    const urlSectionType = 'incidencia'
+    //console.log('NOTICE',this.props.notice)
+
+    return (
+      <NewsContainer>
+        <ImgCol>
+          <ImageWrapper>
+            <a href={`/${urlSectionType}/${this.props.notice.uid}/`}>
+              <img src={banner.thumbnail.url} alt={banner.thumbnail.url || banner.alt || ''} />
+            </a>
+          </ImageWrapper>
+        </ImgCol>
+        <TextCol>
+          <NewsText>
+            <h3>
+              <a href={`/${urlSectionType}/${this.props.notice.uid}/`}>{title.text}</a>
+            </h3>
+         
+          </NewsText>
+          <DateText>
+            {this.getDate(custom_publishdate)} |{" "}
+            {this.getYear(custom_publishdate)}
+          </DateText>
+        </TextCol>
+        
+      </NewsContainer>
+    )
+  }
+}
+export default SubNewComponent

--- a/src/containers/blog.js
+++ b/src/containers/blog.js
@@ -54,7 +54,7 @@ class BlogContainer extends Component {
         })
       )
       .then(response => {
-        const newData = response.results.map(n => {
+        const almostNewData = response.results.map(n => {
           const excerptLength = n.data.excerpt.length
           const titleLength = n.data.title.length
           const authorLength = n.data.author.length
@@ -64,7 +64,7 @@ class BlogContainer extends Component {
             ? n.data.author[0].name[0].text
             : "Anónimo"
 
-          return {
+          return this.noticeType=="noticias_especiales" ? ({
             uid: n.uid,
             data: {
               banner: {
@@ -75,8 +75,26 @@ class BlogContainer extends Component {
               custom_publishdate: n.data.custom_publishdate,
               author: [{ name: { text: authorText } }],
             },
-          }
+            showOnSpecialNews: n.data.show_on_special_news
+          }): ({
+            uid: n.uid,
+            data: {
+              banner: {
+                thumbnail: { url: n.data.banner.thumbnail.url },
+              },
+              title: { text: titleText },
+              excerpt: { text: excerptText },
+              custom_publishdate: n.data.custom_publishdate,
+              author: [{ name: { text: authorText } }],
+            },
+          })
         })
+        let newData;
+        if(this.noticeType=="noticias_especiales"){
+          newData = almostNewData.filter(n=>n.showOnSpecialNews === null || n.showOnSpecialNews=== true);
+        } else {
+          newData = almostNewData;
+        }
         let newState = {
           data: [...this.state.data, ...newData],
           isFetching: false,

--- a/src/containers/home.js
+++ b/src/containers/home.js
@@ -58,12 +58,12 @@ class HomeContainer extends Component {
           bannerNotices={this.props.bannerNotice}
           principalNotices={this.props.normalNotices}
         />
-        <SpecialNews notices={this.props.specialNotices} />
         <RecentIncidencias
           notices={this.props.recentIncidencias}
           bannerNotices={this.props.bannerNotice}
           principalNotices={this.props.normalNotices}
         />
+        <SpecialNews notices={this.props.specialNotices} />
       </React.Fragment>
     )
   }

--- a/src/containers/home.js
+++ b/src/containers/home.js
@@ -3,6 +3,7 @@ import HomeHeaderComponent from "../components/homeHeader/index.js"
 import MainNewsComponent from "../components/mainNews/index.js"
 import SubscribeComponent from "../components/subscribe/index.js"
 import RecentNews from "../components/recentNews/index.js"
+import RecentIncidencias from "../components/recentIncidencias/index.js"
 import SpecialNews from "../components/specials/index.js"
 import CategoryBlockComponent from "../components/categoryblock/index.js"
 
@@ -37,13 +38,14 @@ class HomeContainer extends Component {
         removeSpecialNotices
       )
     }
+    console.log(this.props)
     return (
       <React.Fragment>
         <HomeHeaderComponent bannerNotice={this.props.bannerNotice} />
         <MainNewsComponent notice={this.props.noticeP} />
         {
           this.props.categories.map(category => 
-            (category.active && <CategoryBlockComponent
+            ((category.active && category.category !== null) && <CategoryBlockComponent
               key={`category-block-${category.prismicId}`}
               category={category}
               site={this.props.site}
@@ -57,6 +59,11 @@ class HomeContainer extends Component {
           principalNotices={this.props.normalNotices}
         />
         <SpecialNews notices={this.props.specialNotices} />
+        <RecentIncidencias
+          notices={this.props.recentIncidencias}
+          bannerNotices={this.props.bannerNotice}
+          principalNotices={this.props.normalNotices}
+        />
       </React.Fragment>
     )
   }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -34,6 +34,7 @@ const temp = data => {
         specialNotices={specialNotices}
         noticeP={common.principal_notices_active ? principalNotices : { nodes: [] }}
         site={data.data.site.siteMetadata}
+        recentIncidencias={data.data.recentIncidencias}
       />
     </Layout>
   )
@@ -269,7 +270,30 @@ export const pageQuery = graphql`
         }
       }
     }
-
+    recentIncidencias: allPrismicIncidencia(
+      limit: 3
+      sort: { fields: [data___custom_publishdate], order: [DESC] }
+    )  {
+        nodes{
+          uid
+          prismicId
+          data {
+            custom_publishdate
+            title {
+              text
+            }
+            banner{
+              url
+              alt
+              thumbnail
+              {
+              	url
+              	alt  
+              }
+            }
+          }
+        }
+    }
   }
 `
 

--- a/src/pages/noticias-especiales.js
+++ b/src/pages/noticias-especiales.js
@@ -11,7 +11,7 @@ const Noticias = data => {
   return (
     <Layout>
       <SEO
-        title="Noticas Especiales"
+        title="Noticias Especiales"
         description={description}
         keywords={keywords}
       />


### PR DESCRIPTION
#### What does this PR do?
Hides news from special news when they're not listed based on the prismic field "show_on_special_news"
Fix page title "noticas especiales" by "noticias especiales"
#### Where should the reviewer start from?
* M `src/containers/blog.js`
* M `src/pages/noticias-especiales.js`

#### notes before merging
Change the base branch to ` feat/home_recent_incidencias` so they can be merged together.
Or just merge this for pushing both changes to production.